### PR TITLE
feat: block sending test email

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -17,6 +17,7 @@ demo.immich.app {
 		path /api/users/profile-image
 		path /api/assets
 		path /api/auth/change-password
+		path /api/notifications/test-email
 	}
 
 	@cors_preflight method OPTIONS


### PR DESCRIPTION
`/api/notifications/test-email` should probably be blocked, because it uses the config provided in the POST request to send a test mail