### PR TITLE
fix: create api key with permissions

### DIFF
--- a/demo-restart.sh
+++ b/demo-restart.sh
@@ -27,7 +27,7 @@ sudo iptables -D INPUT -p tcp --dport 80 -j DROP
 
 accessToken=$(curl -d '{"email": "demo@immich.app", "password": "demo"}' -H "Content-Type: application/json" -X POST 127.0.0.1:3001/api/auth/login | jq -r '.accessToken')
 header="Authorization: Bearer ${accessToken}"
-apiKey=`curl -d '{"name": "Demo controller"}' -H "Content-Type: application/json" -H "$header" -X POST 127.0.0.1:3001/api/api-keys | jq -r '.secret'`
+apiKey=`curl -d '{"name": "Demo controller", "permissions": ["all"]}' -H "Content-Type: application/json" -H "$header" -X POST 127.0.0.1:3001/api/api-keys | jq -r '.secret'`
 
 docker run --rm -v /home/ubuntu/demo/images:/import --network demo_default \
     -e IMMICH_INSTANCE_URL="http://immich-server:3001/api" -e IMMICH_API_KEY="$apiKey" \


### PR DESCRIPTION
This was a breaking change in v1.113.0 and prevents upload of the demo assets